### PR TITLE
docs(agents): split agent guidance; add TypeScript guide and README links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,116 +1,37 @@
 # AGENTS.md
 
-Purpose
--------
+Package-specific agent guidance — mtng-unstorage
+----------------------------------------------
 
-This file documents conventions, rules, and expectations for automated agents (and human reviewers) working on the mtng-unstorage repository. Treat this as the single source of truth for agent behavior, temporary files, release procedures, and code-quality expectations.
+This file contains only repository/package-specific guidance for automated agents working on the `mtng-unstorage` package. For organization-wide conventions, tooling policies, and network usage rules, see `AGENTS_ORGANIZATION.md`.
 
-Core principles
----------------
+Repository-specific notes
+-------------------------
 
-- Non-destructive: avoid making breaking or otherwise risky changes without an associated PR and CI verification.
-- Small, verifiable steps: prefer small commits that are easy to review and validate with the project's prepublish pipeline.
-- Follow the repo tooling: use `pnpm`, `vitest`, `vite`, `eslint`, and the `gh` CLI as documented below.
-- Document changes: every change that affects API/contract (including exported types and helper names) must have a `CHANGELOG.md` entry.
+- `AGENTS_REPO.md` documents repository-level agent guidance.
 
-Repository conventions (short)
------------------------------
+Technology-stack-specific notes
+-------------------------------
 
-- Keep `aws-s3` and `aws-s3-flex` as separate drivers for now. Do not attempt to refactor them into a shared factory unless authorized.
-- Central helpers:
-  - Cross-driver utilities live in `src/utils.ts`.
-  - S3-specific helpers live in `src/drivers/aws-s3/shared.ts`.
-  - Types for S3 drivers live in `src/drivers/aws-s3/types.ts`.
-- Naming conventions:
-  - Prefer explicit S3 helper names: `toS3StorageKey`, `normalizeS3Key`, `joinS3Key`.
-  - Type names use UpperCamelCase: `AwsS3DriverOptions`.
-- Exports:
-  - Drivers and helpers should be re-exported from `src/index.ts` where appropriate. If adding subpath exports, update `package.json` `exports` accordingly.
+This is Typescript package, consult `AGENTS_TYPESCRIPT.md`.
 
-Testing & CI
-------------
-
-- Local prepublish pipeline (required before pushing release or merge PR):
-
-```bash
-pnpm run typecheck    # tsc --noEmit
-pnpm run lint         # eslint src --ext .ts,.js
-pnpm run build        # vite build
-pnpm run test         # vitest run
-```
-
-- E2E tests are located in `tests-e2e/` and are skipped unless environment variables are set (see tests for details). Use `AWS_S3_E2E_ENABLED=true` and a test bucket or LocalStack when running.
-- Keep unit tests fast and isolated: mock external services (like AWS S3) in unit tests.
-
-Temporary files and release notes
---------------------------------
-
-- Temporary release note files such as `RELEASE_BODY_0.2.0.md` may be generated in the repo root to facilitate `gh release create/edit`. Remove these temporary files after use. Agents must not commit temporary release body files unless explicitly requested.
-- If you want permanent release notes in the repo, add them under `docs/release-notes/` and update the todo list and PR description.
-
-Releases and tagging
---------------------
-
-- Version bumps should follow semantic versioning. Because this repository may contain breaking changes when renaming helpers/types, be conservative: bump the major version for breaking changes, minor for new features, patch for fixes. However, while the major version is 0, keep major version at 0. 
-- Release workflow (recommended):
-  1. Bump `package.json` version and update `CHANGELOG.md` (move Unreleased -> `## [x.y.z] - YYYY-MM-DD`).
-  2. Commit and push the changes to the release branch.
-  3. Merge to `main` via PR when CI passes.
-  4. Create an annotated tag on `main` and push it: `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`.
-  5. The GitHub Actions release workflow will publish / create release notes; if necessary, use the `gh` CLI to update the release body from `CHANGELOG.md`.
-
-Sample `gh` usage for temporary release body file:
-
-```bash
-# create temporary file from CHANGELOG (manually or via script)
-gh release create v0.2.0 --notes-file RELEASE_BODY_0.2.0.md -R mtngtools/mtng-unstorage
-# then remove the temp file
-rm RELEASE_BODY_0.2.0.md
-```
-
-Change and breaking-change policy
----------------------------------
-
-- Any removal/rename of public exports, helper functions, or exported type names must be documented under `CHANGELOG.md` in an explicit `### Breaking` section.
-- If you must perform a breaking change, prefer preparing a migration guide (`MIGRATION.md`) and include an automated codemod (jscodeshift) or simple `sed` examples in the PR description.
-
-PR & commit guidelines for agents
----------------------------------
-
-- Create a concise branch name describing the work (e.g., `feat/aws-s3-flex-phase1`).
-- Commit messages should follow the conventional format: `type(scope): short description` (e.g., `feat(aws-s3): add aws-s3-flex driver`).
-- Include in the PR description:
-  - Summary of changes
-  - Files touched
-  - Tests run locally (pass/fail)
-  - Any manual verification steps
-  - Migration notes if applicable
-
-Files of interest (quick map)
-----------------------------
-
-- `src/drivers/aws-s3/aws-s3.ts` — main S3 driver (implementation)
-- `src/drivers/aws-s3/aws-s3-flex.ts` — flex driver (phase1 parity)
-- `src/drivers/aws-s3/shared.ts` — S3-only helpers (normalize/join/toS3StorageKey, validateS3Options)
-- `src/drivers/aws-s3/types.ts` — S3 driver types
-- `src/utils.ts` — cross-driver utilities (serialize/deserialize/streamToString/etc.)
-- `CHANGELOG.md` — canonical release notes
-- `package.json` — exports and version; update `exports` when adding subpath public entry points
-
-Agent tooling etiquette
+Package-specific notes
 ----------------------
 
-- Use the workspace tools (pnpm, vitest, eslint) for verification. Do not call external network services unless the user authorizes it (for E2E you may require AWS credentials or LocalStack details).
-- Do not leave temporary or generated files in the repo. If you create temporary files for GitHub releases or test output, remove them before finishing.
-- When editing files, prefer minimal, focused edits. Preserve style and existing public APIs unless intentionally changing them with a documented breaking change.
+- E2E tests are in `tests-e2e/` and are gated by an environment variable. Do NOT run or publish E2E results unless `AWS_S3_E2E_ENABLED=true` and credentials are provided.
+- Drivers and S3 helpers live under `src/drivers/aws-s3/`. Exercise caution when changing exported helper names — update `CHANGELOG.md` and include migration notes in the PR when making breaking changes.
+- Cross-driver utilities are in `src/utils.ts` and are used by drivers in this package.
 
-If you are unsure
----------------
+Files of interest (package)
+---------------------------
 
-- Ask the user for clarification when a task is ambiguous or would touch public API.
-- If a change requires repository-wide refactor or affects downstream consumers, propose a plan as a PR and request review rather than pushing directly to `main`.
+- `src/drivers/aws-s3/` — S3 driver implementations and helpers
+- `src/utils.ts` — shared helpers
+- `tests-e2e/` — integration/E2E tests (gated)
+- `CHANGELOG.md` — canonical release notes for this package
+- `package.json` — package metadata, exports, and version
 
 
 ----
 
-This file is intended to be short and actionable. Feel free to expand or request additions (e.g., add a sample codemod, CI monitoring steps, or release checklist automation).
+Keep this file short and focused — add only repo/package-specific rules here.

--- a/AGENTS_ORGANIZATION.md
+++ b/AGENTS_ORGANIZATION.md
@@ -1,0 +1,72 @@
+# AGENTS_ORGANIZATION.md
+
+
+Purpose
+-------
+
+This document is the organization-level agent guidance for the mtngtools GitHub organization. It captures the long-term conventions, technology stacks we support, and recommended repository structures. For now, this file lives in this repository as a canonical draft. It will eventually reference or be replaced by a central document in the mtngtools organization-level docs repo (for example: `https://github.com/mtngtools/docs`), and contain links to per-language and per-framework guidance maintained centrally.
+
+Note: this file intentionally contains broader recommendations and references.
+
+
+Multiple levels of guidance
+---------------------------
+
+Multiple levels of guidance exist to help agents navigate the various aspects of their work.
+
+- Organization-level guidance (this file)
+- Repo-level guidance (`AGENTS_REPO.md`)
+- Package-level guidance (`AGENTS.md`)
+- Tech stack-specific guidance (for example `AGENTS_TYPESCRIPT.md`)
+
+Every repository or package should reference each of these four levels.
+
+Table of contents
+-----------------
+
+- Purpose
+- Multiple levels of guidance
+- Audience & quick start
+- Language-specific guides
+- Agent behavior — organization rules
+- Tool calling & network-usage policies
+- Maintenance and ownership
+
+Audience & quick start
+---------------------
+
+- Audience: automated agents, maintainers, and contributors who work across repositories in the mtngtools organization.
+- Quick start (2 steps):
+  1. Run local verification (typecheck → lint → build → unit tests) and open a PR for changes.
+  2. Consult the language-specific agent guide for tool-specific commands (for TypeScript see `AGENTS_TYPESCRIPT.md`).
+
+Agent behavior—organization rules
+--------------------------------
+
+- Agents must be conservative: prefer making small commits and open PRs rather than direct pushes to default branches.
+- Agents should run the minimal verification steps before pushing changes: typecheck → lint → build → unit tests.
+- Any release or tag creation should be coordinated and follow the organization's release checklist; prefer creating PRs that include release notes rather than creating tags directly from agents.
+- Do not start work on features or bug fixes if:
+  - you are on the `main` branch or another protected branch
+  - there is no GitHub issue or task tracking the work
+
+Tool calling & network-usage policies (organization)
+--------------------------------------------------
+
+These rules govern how automated agents should call tools, access network services, and interact with external systems. They are written to be intentionally conservative — security and auditability are primary concerns.
+
+- Prefer local verification before network calls: agents should run the local prepublish pipeline (typecheck → lint → build → test) and only call remote services when necessary.
+- Do not call external network services unless explicitly authorized by a human or by repository configuration (for example CI jobs that run with appropriate credentials). Examples of authorized scenarios include:
+  - CI jobs that run with organization-managed credentials (e.g., GitHub Actions runners with secrets configured).
+  - E2E jobs gated by environment variables (for example `AWS_S3_E2E_ENABLED=true`) where the environment provides credentials.
+- Never exfiltrate secrets. Agents must not print or commit sensitive values (API keys, AWS credentials, private tokens). When a tool requires a token, use environment variables or secure secret stores provided by CI.
+- Use the `gh` CLI or provider APIs only when necessary and with explicit intent. When updating releases or creating tags programmatically, prefer creating a PR that documents the intent and includes the release notes; a maintainer can then merge the PR to trigger release automation.
+- Temporary files created to interact with remote services (for example temporary `RELEASE_BODY_*.md` used with `gh release create`) must be deleted before finishing the run and must not be committed to the repository.
+- Agents must be conservative with writes: prefer opening a PR with minimal diffs rather than pushing directly to protected branches. Server-side protections (branch rules) are the authoritative enforcement mechanism.
+- When an agent needs to perform destructive or privileged operations (publish to npm, create GitHub releases, modify branch protection rules), require an explicit approval step recorded in a PR or an issue comment from a maintainer.
+- Logging and audit: agents should emit concise logs describing the actions they intend to perform (why/what/outcome) and any external calls; these logs should avoid leaking secrets and be stored where maintainers can inspect them (for example CI logs or a secured artifact store).
+
+
+----
+
+This file is a living draft. When organization-level docs repo is available, convert this file to an index that references the central source-of-truth.

--- a/AGENTS_REPO.md
+++ b/AGENTS_REPO.md
@@ -1,0 +1,8 @@
+
+# AGENTS_REPO.md
+
+Follow organization-level rules in `AGENTS_ORGANIZATION.md`.
+
+- This is a single-package repository.
+- See `AGENTS.md` for package-specific guidance.
+

--- a/AGENTS_TYPESCRIPT.md
+++ b/AGENTS_TYPESCRIPT.md
@@ -1,0 +1,61 @@
+# AGENTS_TYPESCRIPT.md
+
+TypeScript tooling & stacks (agent guidance)
+-------------------------------------------
+
+This document contains TypeScript-specific tooling choices and minimal verification steps agents should run when working on TypeScript projects in the mtngtools organization.
+
+What to check (quick)
+---------------------
+
+- Run local verification: `pnpm run typecheck && pnpm run lint && pnpm run build && pnpm run test`.
+- For E2E: ensure environment gating variable is set (e.g., `AWS_S3_E2E_ENABLED=true`) and documented in the PR.
+- When using `gh api` or `gh release`, include a PR or human-authored description and remove temporary files after use.
+- Avoid direct pushes to protected branches; open a PR and request the appropriate reviewers (use `CODEOWNERS` where helpful).
+
+Tooling sections
+----------------
+
+Vite
+
+- Rationale: fast dev server and build tooling for modern TS projects, good DX and d.ts generation with plugins.
+- Typical files: `vite.config.ts`, `tsconfig.json`, `package.json` scripts (build/preview/dev).
+- Agent checks: `pnpm run build` (should succeed), ensure `vite-plugin-dts` is configured if the project exports types.
+- Notes: ensure build outputs land in `dist/` and that d.ts files are generated when needed for packages.
+
+Vitest
+
+- Rationale: lightweight, fast unit test runner that integrates well with Vite.
+- Typical files: `vitest.config.ts`, `vitest.setup.ts`.
+- Agent checks: `pnpm run test` or `pnpm run test:ci` for headless runs. Prefer unit tests mock external services; E2E tests should be gated by environment variables.
+
+ESLint
+
+- Rationale: enforce style and catch common bugs early.
+- Typical files: `.eslintrc.js` or `.eslintrc.cjs`; share rules via an org preset when possible.
+- Agent checks: `pnpm run lint` and fail PRs on lint errors (or require autofix before merge).
+
+TypeScript (tsc)
+
+- Rationale: static typing and API guarantees.
+- Typical files: `tsconfig.json`, `tsconfig.build.json` (if needed).
+- Agent checks: `pnpm run typecheck` (`tsc --noEmit`) as part of CI/prepublish.
+
+Nuxt / Nitro / Vue / Unjs (frameworks)
+
+- Rationale: for web apps or full-stack projects using Vue/Nuxt/Nitro. When a repo uses these frameworks, include framework-specific agent checks (build + server-side rendering tests).
+- Typical files: `nuxt.config.ts`, `nitro.config.ts`, Vue single-file components, and `package.json` scripts.
+- Agent checks: `pnpm run build` (Nuxt/Nitro build), verify SSR entry points if publishing server bundles.
+- Notes: E2E tests for frameworks should run in separate CI job and be optional for PRs (unless small and fast).
+
+Monorepo specifics (TypeScript)
+
+- Use `pnpm` workspaces for multi-package repos. Keep `pnpm-workspace.yaml` at the root and list packages explicitly (for example `packages/*`).
+- Prefer multiple small packages with clear responsibilities over a single huge package.
+- Use CI that runs per-package tests in parallel and a top-level integration job for cross-package E2E.
+- Versioning strategies: independent (per-package) with `changesets` or fixed single-version for tightly-coupled packages.
+
+Notes
+-----
+
+This file is focused on TypeScript tool choices and verification steps. For organization-wide policies about network usage, secrets, and agent behavior that apply regardless of language, see `AGENTS_ORGANIZATION.md`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ console.log(user) // { name: 'John', email: 'john@example.com' }
 - **[All Drivers Overview](./docs/drivers/README.md)** - Comparison and overview of all drivers
 - **[AWS S3 Driver](./docs/drivers/aws-s3.md)** - Complete AWS S3 driver documentation
 
+### Agent guidance
+
+- Organization-wide agent guidance: [`AGENTS_ORGANIZATION.md`](./AGENTS_ORGANIZATION.md)
+- TypeScript-specific agent guidance: [`AGENTS_TYPESCRIPT.md`](./AGENTS_TYPESCRIPT.md)
+- Repo-level agent guidance (minimal): [`AGENTS_REPO.md`](./AGENTS_REPO.md)
+- Package-specific agent guidance: [`AGENTS.md`](./AGENTS.md)
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
This PR reorganizes and splits agent guidance into four focused files and updates the README links:

- Add `AGENTS_ORGANIZATION.md` — organization-level agent guidance (language-agnostic, tool/network policies, behavior rules).
- Add `AGENTS_TYPESCRIPT.md` — TypeScript-specific tooling and quick-checklist (Vite, Vitest, ESLint, tsc, monorepo notes).
- Shorten `AGENTS_REPO.md` — minimal repo-level pointer to org and package guides.
- Replace `AGENTS.md` with a short package-specific guide for `mtng-unstorage`.
- Update `README.md` to reference the new agent docs and reorder links.

Why:
- Keeps organization-level policies separate from language/tool specifics.
- Makes package-level guidance minimal and easy to find.

Notes for reviewers:
- No production code changes — docs only.
- Quick review: ensure links and wording look right and that the README placement is acceptable.
