### PR TITLE
refactor(drivers)!: conditionally return methods based on options (#26)

### DIFF
--- a/src/drivers/aws-s3/aws-s3-common.test.ts
+++ b/src/drivers/aws-s3/aws-s3-common.test.ts
@@ -126,11 +126,11 @@ export function registerAwsS3CommonTests(args: {
     })
 
     describe('readOnly mode', () => {
-      it('blocks setItem/removeItem/clear', async () => {
+      it('does not return setItem/removeItem/clear methods', () => {
         const driver = makeDriver({ ...defaultOptionsBase, s3Client: mockClient, readOnly: true })
-        await expect(driver.setItem('k', 'v', {})).rejects.toThrow('driver is in read-only mode')
-        await expect(driver.removeItem('k', {})).rejects.toThrow('driver is in read-only mode')
-        await expect(driver.clear('', {})).rejects.toThrow('driver is in read-only mode')
+        expect(driver.setItem).toBeUndefined()
+        expect(driver.removeItem).toBeUndefined()
+        expect(driver.clear).toBeUndefined()
       })
 
       it('allows read operations', async () => {
@@ -143,22 +143,22 @@ export function registerAwsS3CommonTests(args: {
     })
 
     describe('allowClear option', () => {
-      it('blocks clear when allowClear false', async () => {
+      it('does not return clear when allowClear false', () => {
         const driver = makeDriver({ ...defaultOptionsBase, s3Client: mockClient, allowClear: false })
-        await expect(driver.clear('', {})).rejects.toThrow('allowClear option must be set to true')
+        expect(driver.clear).toBeUndefined()
       })
-      it('blocks clear when allowClear undefined', async () => {
-        const { allowClear, ...rest } = defaultOptionsBase as any
+      it('does not return clear when allowClear undefined', () => {
+        const { allowClear: _, ...rest } = defaultOptionsBase as any
         const driver = makeDriver({ ...rest, s3Client: mockClient })
-        await expect(driver.clear('', {})).rejects.toThrow('allowClear option must be set to true')
+        expect(driver.clear).toBeUndefined()
       })
-      it('allows clear when allowClear true', async () => {
+      it('returns clear when allowClear true', () => {
         const driver = makeDriver({ ...defaultOptionsBase, s3Client: mockClient })
-        await expect(driver.clear('', {})).resolves.toBeUndefined()
+        expect(typeof driver.clear).toBe('function')
       })
-      it('still checks readOnly first', async () => {
-        const driver = makeDriver({ ...defaultOptionsBase, s3Client: mockClient, readOnly: true })
-        await expect(driver.clear('', {})).rejects.toThrow('driver is in read-only mode')
+      it('does not return clear when readOnly is true even if allowClear is true', () => {
+        const driver = makeDriver({ ...defaultOptionsBase, s3Client: mockClient, readOnly: true, allowClear: true })
+        expect(driver.clear).toBeUndefined()
       })
     })
   })

--- a/src/drivers/aws-s3/aws-s3-flex.ts
+++ b/src/drivers/aws-s3/aws-s3-flex.ts
@@ -2,7 +2,7 @@ import type { PutObjectCommandInput } from '@aws-sdk/client-s3';
 import { defineDriver } from 'unstorage';
 import type { AwsS3FlexDriverOptions, S3PutObjectOptions } from './types';
 import { mapUnstorageKeyToS3Key, validateS3Options, createS3Client, mapS3ObjectKeyToUnstorageKey, getS3Body, putS3Object, deleteS3Object, listS3KeysMapped, getS3Head } from './shared.js';
-import { checkReadOnly, clearByListingAndBatching, streamToString } from '../../utils.js';
+import { clearByListingAndBatching, streamToString } from '../../utils.js';
 import { AWS_S3_FLEX_DRIVER_NAME } from './types.js';
 import { MTBaseDriverRequestOptions } from '../../types.js';
 
@@ -21,7 +21,7 @@ export default defineDriver((options: AwsS3FlexDriverOptions) => {
     storagePrefix: options.storagePrefix ?? options.s3StoragePrefix ?? '',
   });
 
-  const { bucket: Bucket, name, readOnly = false } = resolvedDriverOptions;
+  const { bucket: Bucket, name, readOnly = false, allowClear = false } = resolvedDriverOptions;
 
   // Build client if not provided using shared helper
   const client = createS3Client(resolvedDriverOptions);
@@ -76,7 +76,6 @@ export default defineDriver((options: AwsS3FlexDriverOptions) => {
     opts?: MTBaseDriverRequestOptions & { s3Options?: S3PutObjectOptions },
   ): Promise<void> {
     // console.debug(`aws-s3-flex storage setItem -- KEY: ${key}  -- Bucket: ${Bucket}`);
-    checkReadOnly(readOnly, 'setItem');
     const body = toStorageValue ? await toStorageValue(value, resolvedDriverOptions as any, opts) : value;
     await putS3Object(
       client,
@@ -90,7 +89,6 @@ export default defineDriver((options: AwsS3FlexDriverOptions) => {
   }
 
   async function removeItem(key: string, opts?: MTBaseDriverRequestOptions): Promise<void> {
-    checkReadOnly(readOnly, 'removeItem');
     await deleteS3Object(client, {
       Bucket,
       Key: mapToS3Key(key, resolvedDriverOptions, opts),
@@ -119,16 +117,27 @@ export default defineDriver((options: AwsS3FlexDriverOptions) => {
     });
   }
 
-  return {
+  // Build return object conditionally based on options
+  const driver: any = {
     name,
     flags: {
       maxDepth: true,
     },
     hasItem,
     getItem,
-    setItem,
-    removeItem,
     getKeys,
-    clear,
   };
+
+  // Only include write methods if not read-only
+  if (!readOnly) {
+    driver.setItem = setItem;
+    driver.removeItem = removeItem;
+  }
+
+  // Only include clear if not read-only AND allowClear is true
+  if (!readOnly && allowClear) {
+    driver.clear = clear;
+  }
+
+  return driver;
 });

--- a/src/drivers/aws-s3/aws-s3.common.integration.test.ts
+++ b/src/drivers/aws-s3/aws-s3.common.integration.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { createStorage } from 'unstorage'
 import awsS3Driver from './aws-s3.js'
 import awsS3FlexDriver from './aws-s3-flex.js'
-import { AWS_S3_DRIVER_NAME, AWS_S3_FLEX_DRIVER_NAME } from './types.js'
 import { MockS3Client } from '../../../tests/helpers/mock-s3.js'
 
 // Common integration test registration for both base and flex S3 drivers using mounted storage instances
@@ -166,10 +165,11 @@ export function registerAwsS3CommonIntegrationTests(args: {
         readOnlyStorage.mount('readonly', makeDriver({ ...defaultOptionsBase, s3Client: mockClient, readOnly: true }))
       })
 
-      it('blocks setItem/removeItem/clear via storage interface', async () => {
-        await expect(readOnlyStorage.setItem('readonly:k', 'v')).rejects.toThrow('driver is in read-only mode')
-        await expect(readOnlyStorage.removeItem('readonly:k')).rejects.toThrow('driver is in read-only mode')
-        await expect(readOnlyStorage.clear('readonly')).rejects.toThrow('driver is in read-only mode')
+      it('does not have setItem/removeItem/clear methods on driver', () => {
+        const driver = makeDriver({ ...defaultOptionsBase, s3Client: mockClient, readOnly: true })
+        expect(driver.setItem).toBeUndefined()
+        expect(driver.removeItem).toBeUndefined()
+        expect(driver.clear).toBeUndefined()
       })
 
       it('allows read operations via storage interface', async () => {
@@ -181,27 +181,24 @@ export function registerAwsS3CommonIntegrationTests(args: {
     })
 
     describe('allowClear option', () => {
-      it('blocks clear when allowClear false via storage interface', async () => {
-        const noClearStorage = createStorage()
-        noClearStorage.mount('noclear', makeDriver({ ...defaultOptionsBase, s3Client: mockClient, allowClear: false }))
-        await expect(noClearStorage.clear('noclear')).rejects.toThrow('allowClear option must be set to true')
+      it('does not return clear when allowClear false', () => {
+        const driver = makeDriver({ ...defaultOptionsBase, s3Client: mockClient, allowClear: false })
+        expect(driver.clear).toBeUndefined()
       })
 
-      it('blocks clear when allowClear undefined via storage interface', async () => {
-        const { allowClear, ...rest } = defaultOptionsBase as any
-        const undefinedClearStorage = createStorage()
-        undefinedClearStorage.mount('undefined', makeDriver({ ...rest, s3Client: mockClient }))
-        await expect(undefinedClearStorage.clear('undefined')).rejects.toThrow('allowClear option must be set to true')
+      it('does not return clear when allowClear undefined', () => {
+        const { allowClear: _, ...rest } = defaultOptionsBase as any
+        const driver = makeDriver({ ...rest, s3Client: mockClient })
+        expect(driver.clear).toBeUndefined()
       })
 
-      it('allows clear when allowClear true via storage interface', async () => {
+      it('returns clear when allowClear true via storage interface', async () => {
         await expect(storage.clear('data')).resolves.toBeUndefined()
       })
 
-      it('still checks readOnly first via storage interface', async () => {
-        const readOnlyNoClearStorage = createStorage()
-        readOnlyNoClearStorage.mount('readonly', makeDriver({ ...defaultOptionsBase, s3Client: mockClient, readOnly: true }))
-        await expect(readOnlyNoClearStorage.clear('readonly')).rejects.toThrow('driver is in read-only mode')
+      it('does not return clear when readOnly is true even if allowClear is true', () => {
+        const driver = makeDriver({ ...defaultOptionsBase, s3Client: mockClient, readOnly: true, allowClear: true })
+        expect(driver.clear).toBeUndefined()
       })
     })
   })

--- a/src/drivers/aws-s3/aws-s3.ts
+++ b/src/drivers/aws-s3/aws-s3.ts
@@ -2,7 +2,7 @@ import type { PutObjectCommandInput } from '@aws-sdk/client-s3';
 import { defineDriver } from 'unstorage';
 import type { AwsS3DriverOptions, S3PutObjectOptions } from './types';
 import { mapUnstorageKeyToS3Key, validateS3Options, createS3Client, mapS3ObjectKeyToUnstorageKey, getS3Body, putS3Object, deleteS3Object, listS3KeysMapped, getS3Head } from './shared.js';
-import { checkReadOnly, streamToString, clearByListingAndBatching } from '../../utils.js';
+import { streamToString, clearByListingAndBatching } from '../../utils.js';
 import { AWS_S3_DRIVER_NAME } from './types.js';
 import { MTBaseDriverRequestOptions } from '../../types.js';
 
@@ -18,7 +18,7 @@ export default defineDriver((options: AwsS3DriverOptions) => {
     storagePrefix: options.storagePrefix ?? options.s3StoragePrefix ?? '',
   });
 
-  const { bucket: Bucket, name, readOnly = false } = resolvedDriverOptions;
+  const { bucket: Bucket, name, readOnly = false, allowClear = false } = resolvedDriverOptions;
 
   // Build client if not provided using shared helper
   const client = createS3Client(resolvedDriverOptions);
@@ -61,7 +61,6 @@ export default defineDriver((options: AwsS3DriverOptions) => {
     opts?: { s3Options?: S3PutObjectOptions },
   ): Promise<void> {
     // console.debug(`aws-s3 storage setItem -- KEY: ${key}  -- Bucket: ${Bucket}  -- fullBasePrefix: ${fullBasePrefix}`);
-    checkReadOnly(readOnly, 'setItem');
     await putS3Object(
       client,
       {
@@ -75,8 +74,6 @@ export default defineDriver((options: AwsS3DriverOptions) => {
 
   async function removeItem(key: string, _opts: any): Promise<void> {
     // console.debug(`aws-s3 storage removeItem -- KEY: ${key}  -- Bucket: ${Bucket}  -- fullBasePrefix: ${fullBasePrefix}`);
-    checkReadOnly(readOnly, 'removeItem');
-
     await deleteS3Object(client, {
       Bucket,
       Key: mapUnstorageKeyToS3Key(key, resolvedDriverOptions),
@@ -106,16 +103,27 @@ export default defineDriver((options: AwsS3DriverOptions) => {
     });
   }
 
-  return {
+  // Build return object conditionally based on options
+  const driver: any = {
     name,
     flags: {
       maxDepth: true,
     },
     hasItem,
     getItem,
-    setItem,
-    removeItem,
     getKeys,
-    clear,
   };
+
+  // Only include write methods if not read-only
+  if (!readOnly) {
+    driver.setItem = setItem;
+    driver.removeItem = removeItem;
+  }
+
+  // Only include clear if not read-only AND allowClear is true
+  if (!readOnly && allowClear) {
+    driver.clear = clear;
+  }
+
+  return driver;
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { validateKey, serialize, deserialize } from './utils.js';
-import { filterKeyByDepth, checkReadOnly, streamToString } from './utils.js';
+import { filterKeyByDepth, streamToString } from './utils.js';
 
 describe('Utils', () => {
   // removed legacy serialize/deserialize tests
@@ -78,16 +78,6 @@ describe('Utils', () => {
       expect(filterKeyByDepth('top:child', 1)).toBe(true)
       expect(filterKeyByDepth('a:b:c:d', 2)).toBe(false)
       expect(filterKeyByDepth('a:b:c', 2)).toBe(true)
-    })
-  })
-
-  describe('checkReadOnly', () => {
-    it('should throw when readOnly is true', () => {
-      expect(() => checkReadOnly(true, 'setItem')).toThrow('Cannot perform setItem: driver is in read-only mode')
-    })
-
-    it('should not throw when readOnly is false', () => {
-      expect(() => checkReadOnly(false, 'setItem')).not.toThrow()
     })
   })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,17 +60,6 @@ export const filterKeyByDepthByOptions = (
   ) => filterKeyByDepth(key, requestOpts?.maxDepth ?? resolvedDriverOptions.maxDepth ?? undefined);
 
 /**
- * Throws when the driver is in read-only mode.
- *
- * Usage: call with the driver-level `readOnly` flag and the operation name.
- */
-export function checkReadOnly(readOnly: boolean, operation: string): void {
-  if (readOnly) {
-    throw new Error(`Cannot perform ${operation}: driver is in read-only mode`);
-  }
-}
-
-/**
  * Resolved base driver options — canonicalized defaults applied.
  * Fields that drivers rely on at runtime (set by validation helpers) are
  * marked required here so callers implementing mapping functions can rely
@@ -141,14 +130,7 @@ export async function clearByListingAndBatching(args: {
   removeItem: (key: string, opts: any) => Promise<void>;
   batchSize?: number;
 }): Promise<void> {
-  const { opts, baseToClear, resolvedDriverOptions, getKeys, removeItem, batchSize = 100 } = args;
-  const { readOnly, allowClear } = resolvedDriverOptions;
-
-  checkReadOnly(readOnly, 'clear');
-
-  if (!allowClear) {
-    throw new Error('Cannot perform clear: allowClear option must be set to true');
-  }
+  const { opts, baseToClear, getKeys, removeItem, batchSize = 100 } = args;
 
   const keys = await getKeys(baseToClear || '', opts);
 


### PR DESCRIPTION
## Summary

Refactors AWS S3 drivers to conditionally return methods based on `readOnly` and `allowClear` options, rather than returning all methods and throwing runtime errors.

## Changes

- **Conditional method return**: Methods are only returned if they are allowed
  - When `readOnly: true`: `setItem`, `removeItem`, and `clear` are not returned
  - When `allowClear: false` or undefined: `clear` is not returned (even if not read-only)
- **Removed runtime checks**: All `checkReadOnly()` calls and `allowClear` checks removed since methods won't be returned if not allowed
- **Removed utility function**: `checkReadOnly()` function removed from `utils.ts` as it's no longer needed
- **Updated tests**: Tests now verify methods are `undefined` when disabled instead of checking for runtime errors

## Breaking Changes

⚠️ **BREAKING CHANGE**: Methods are no longer returned when disabled by options. Code that:
- Checks for method existence (e.g., `if (driver.setItem)`) will need to be updated
- Calls disabled methods will now get `undefined is not a function` errors instead of custom error messages
- Relies on runtime error messages for disabled methods will need to check for method existence first

## Testing

- ✅ All 135 tests pass
- ✅ Typecheck passes
- ✅ Build succeeds
- ✅ Lint passes (only pre-existing warnings)

Closes #26