### PR TITLE
feat(docs): expand driver specifications and refine tone

### DIFF
--- a/.env.test.e2e
+++ b/.env.test.e2e
@@ -3,6 +3,7 @@
 
 # Enable/disable E2E tests
 AWS_S3_E2E_ENABLED=false
+AWS_SSM_E2E_ENABLED=false
 
 # AWS S3 Configuration for E2E tests
 # Replace with your actual test bucket name
@@ -10,6 +11,7 @@ AWS_S3_TEST_BUCKET=your-test-bucket-name-here
 
 # Prefix for test data isolation (recommended to include your username)
 AWS_S3_TEST_PREFIX=test-mtng-unstorage-e2e-
+AWS_SSM_TEST_PREFIX=/test/mtng-unstorage/e2e
 
 # AWS Region (optional - will use your default AWS configuration if not set)
 # AWS_REGION=us-east-1

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,30 @@
+# mtng-unstorage Specifications
+
+**mtng-unstorage** provides custom storage drivers for [unstorage](https://unjs.io/unstorage), focused on AWS services support with type-safe configuration and flexible data mapping.
+
+## Overview
+
+This package offers a set of drivers that extend the standard `unstorage` capabilities:
+
+- **Base Drivers**: Standard key-value storage operations.
+- **Flex Drivers**: Advanced drivers with custom key and value mapping (e.g., for legacy S3 paths or automatic JSON serialization).
+- **Versioned Drivers**: (Planned) Support for versioned storage operations.
+
+## Architecture
+
+The library is structured around a core set of types and granular driver implementations.
+
+### 1. Types & Interfaces
+Core definitions that ensure consistency across all drivers.
+- [Base Types](types/base.md): Common options (`readOnly`, `allowClear`) and driver interfaces.
+- [Flex Types](types/flex.md): Advanced mapping configuration for Flex drivers.
+- [Versioned Types](types/versioned.md): (Planned) Versioning interfaces.
+
+### 2. Drivers
+Specific storage backend implementations.
+- [AWS S3](drivers/aws-s3/README.md): S3 driver supporting standard and flex modes.
+- [AWS SSM](drivers/aws-ssm/README.md): Systems Manager Parameter Store driver.
+- [AWS DynamoDB](drivers/aws-ddb/README.md): DynamoDB key-value driver.
+
+### 3. Testing
+- [Testing Strategy](testing.md): Overview of unit and E2E testing approaches.

--- a/spec/drivers/aws-ddb/README.md
+++ b/spec/drivers/aws-ddb/README.md
@@ -1,0 +1,37 @@
+# AWS DynamoDB Driver Specifications (aws-ddb)
+
+## Overview
+The AWS DynamoDB driver enables using Amazon DynamoDB as a key-value storage backend.
+
+## Configuration
+
+For details on common driver options and advanced features, refer to the [Base](../../types/base.md), [Flex](../../types/flex.md), and [Versioned](../../types/versioned.md) type specifications.
+
+### AWS General Options
+| Option | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `region` | `string` | **Yes** | AWS Region (e.g., `us-east-1`). |
+| `accessKeyId` | `string` | No | AWS Access Key ID. |
+| `secretAccessKey` | `string` | No | AWS Secret Access Key. |
+| `sessionToken` | `string` | No | Optional session token. |
+| `dynamoDbClient` | `DynamoDBClient` | No | Pre-configured AWS SDK v3 client instance. |
+
+\* Credentials can be omitted if `dynamoDbClient` is provided or if using environment variables/IAM roles supported by the AWS SDK default provider chain.
+
+### DynamoDB Specific Options
+| Option | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `tableName` | `string` | **Yes** | The DynamoDB table name. |
+
+## Behavior
+
+### Table Schema
+The driver expects a table with a primary key (partition key) to store the item key.
+- **Default Partition Key**: `pk` (string).
+- **Default Value Attribute**: `value` (string or binary).
+
+### Operations
+- **`setItem`**: Puts an item into the table (`PutItem`).
+- **`getItem`**: Gets an item from the table (`GetItem`).
+- **`removeItem`**: Deletes an item (`DeleteItem`).
+- **`getKeys`**: Scans table for keys (Note: Scan operations can be expensive).

--- a/spec/drivers/aws-s3/README.md
+++ b/spec/drivers/aws-s3/README.md
@@ -1,0 +1,68 @@
+# AWS S3 Driver Specifications (aws-s3)
+
+## Overview
+The AWS S3 driver provides a backend for storing items in Amazon S3. It supports standard operations and includes a flexible variant for advanced use cases.
+
+**Source**: `src/drivers/aws-s3/`
+
+## Drivers
+
+This package exports two main driver factories:
+
+- **`awsS3Driver`**: Standard S3 driver. Simplest configuration.
+- **`awsS3FlexDriver`**: Flex driver with custom key/value mapping support.
+
+## Configuration (`AwsS3DriverOptions`)
+
+For details on common driver options and advanced features, refer to the [Base](../../types/base.md), [Flex](../../types/flex.md), and [Versioned](../../types/versioned.md) type specifications.
+
+All S3 drivers require standard AWS SDK credentials and bucket configuration.
+
+### AWS General Options
+| Option | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `region` | `string` | No* | AWS Region (e.g., `us-east-1`). Required if client not provided. |
+| `accessKeyId` | `string` | No* | AWS Access Key ID. |
+| `secretAccessKey` | `string` | No* | AWS Secret Access Key. |
+| `sessionToken` | `string` | No | Optional session token. |
+| `s3Client` | `S3Client` | No | Pre-configured AWS SDK v3 client instance. |
+
+\* Credentials can be omitted if `s3Client` is provided or if using environment variables/IAM roles supported by the AWS SDK default provider chain.
+
+### S3 Specific Options
+| Option | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `bucket` | `string` | **Yes** | The S3 bucket name. |
+
+## Behavior
+
+### Key Mapping
+- **Default**: Keys are treated as S3 object keys. Optional `base` or `storagePrefix` are prepended.
+- **Flex Driver**: Can be overridden with `toStorageKey` / `fromStorageKey`.
+
+### Value Serialization
+- **Default**: Values are stored as raw strings/bytes.
+- **Flex Driver**: Can be overridden with `toStorageValue` / `fromStorageValue` (e.g., for JSON).
+
+### Operations
+- **`setItem`**: Uploads object to S3.
+- **`getItem`**: Downloads object from S3. returns `null` if not found (404).
+- **`removeItem`**: Deletes object from S3.
+- **`getKeys`**: Lists objects in bucket (paginated internally).
+- **`clear`**: Deletes all objects under the configured prefix. **Use with caution**.
+
+## Example
+
+```typescript
+import { awsS3Driver } from '@mtngtools/unstorage';
+
+const storage = awsS3Driver({
+  bucket: 'my-app-storage',
+  region: 'us-west-2',
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+});
+
+await storage.setItem('user:123', 'some data');
+const data = await storage.getItem('user:123');
+```

--- a/spec/drivers/aws-ssm/README.md
+++ b/spec/drivers/aws-ssm/README.md
@@ -1,0 +1,35 @@
+# AWS Systems Manager Parameter Store Driver Specifications (aws-ssm)
+
+## Overview
+The AWS Systems Manager (SSM) driver enables using AWS Parameter Store as a key-value storage backend.
+
+## Configuration
+
+For details on common driver options and advanced features, refer to the [Base](../../types/base.md) and [Flex](../../types/flex.md) type specifications. aws-ssm does not currently support versioning.
+
+### AWS General Options
+| Option | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `region` | `string` | **Yes** | AWS Region (e.g., `us-east-1`). |
+| `accessKeyId` | `string` | No | AWS Access Key ID. |
+| `secretAccessKey` | `string` | No | AWS Secret Access Key. |
+| `sessionToken` | `string` | No | Optional session token. |
+| `ssmClient` | `SSMClient` | No | Pre-configured AWS SDK v3 client instance. |
+
+### SSM Specific Options
+*None currently required beyond standard AWS options.*
+
+## Behavior
+
+### Key Mapping
+- Keys are mapped to SSM parameter names.
+- Recommended to use hierarchical keys (e.g., `/my-app/config/key`) which map well to `unstorage` colon-separated keys.
+
+### Operations
+- **`setItem`**: Creates or updates a parameter (`PutParameter`).
+- **`getItem`**: Retrieves a parameter value (`GetParameter`).
+- **`removeItem`**: Deletes a parameter (`DeleteParameter`).
+- **`getKeys`**: Lists parameters by path (`GetParametersByPath`).
+- **`clear`**: Deletes all parameters under the configured prefix.
+    - **Constraint**: Requires `allowClear: true` **AND** a non-empty `storagePrefix` (or `base`).
+    - **Safety**: Cannot be run on the root path `/` to prevent accidental deletion of all account parameters.

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -1,0 +1,58 @@
+# Testing Strategy
+
+## Overview
+Testing ensures reliability and correctness across drivers, especially when interacting with external services like AWS S3.
+
+## Frameworks
+- **Test Runner**: [Vitest](https://vitest.dev/)
+- **Linting**: [Oxlint](https://oxc-project.github.io/docs/guide/usage/linter.html)
+
+## Test Types
+
+### 1. Unit Tests (`tests/**/*.test.ts`)
+- **Scope**: Individual functions and utilities.
+- **Focus**: Logic verification, edge cases, and mocked interactions.
+- **Command**: `pnpm test`
+
+### 2. Integration / E2E Tests (`tests/**/*.e2e.test.ts`)
+- **Scope**: Full driver workflows against real services (or high-fidelity mocks like LocalStack).
+- **Focus**: Verify S3 connectivity, permission handling, and data integrity.
+- **Configuration**: `vitest.e2e.config.ts`
+- **Command**: `pnpm run test:e2e`
+
+## Testing Patterns
+
+We follow a consistent pattern for both **Integration** and **E2E** test suites to ensure both standard compliance and custom feature verification.
+
+### 1. Core Compliance Tests (`drivers-core`)
+These tests mirror the standard test suite from `unjs/unstorage`.
+- **Purpose**: Ensure our drivers behave exactly like standard unstorage drivers.
+- **Scope**: Basic `setItem`, `getItem`, `removeItem`, `getKeys`.
+- **File Pattern**: `tests/**/drivers-core.test.ts`
+
+### 2. mtngTOOLS Specific Tests (`drivers-mt`)
+These tests cover features unique to `mtng-unstorage` that go beyond the standard spec.
+- **Purpose**: Verify advanced functionality like Flex drivers, custom mapping, and versioning.
+- **Scope**: Flex driver configuration, key/value mapping, conditional methods (`readOnly`).
+- **File Pattern**: `tests/**/drivers-mt.test.ts`
+
+### 3. Provider Tests
+Shared logic for setting up test environments (e.g., temporary S3 buckets or mocked clients) is centralized in `tests/providers/`.
+
+## E2E Test Configuration
+
+E2E tests require specific environment variables to run against real AWS services. These can be set in a `.env.test.e2e.local` file (mirrored from `.env.test.e2e`).
+
+| Variable | Description | Default |
+| :--- | :--- | :--- |
+| `AWS_S3_E2E_ENABLED` | Set to `true` to run S3 E2E tests. | `false` |
+| `AWS_SSM_E2E_ENABLED` | Set to `true` to run SSM E2E tests. | `false` |
+| `AWS_S3_TEST_BUCKET` | Name of the S3 bucket to use for testing. | - |
+| `AWS_S3_TEST_PREFIX` | Key prefix for test isolation. | `test-mtng-unstorage-e2e-` |
+| `AWS_SSM_TEST_PREFIX` | Key prefix (path) for test isolation. | `/test/mtng-unstorage/e2e` |
+| `AWS_REGION` | AWS Region to use. | System default |
+
+**Note**: Standard AWS credentials (`AWS_ACCESS_KEY_ID`, etc.) must also be available via environment variables or local configuration files.
+
+## Continuous Integration
+Tests are run automatically on PRs via GitHub Actions to ensure no regressions.

--- a/spec/types/README.md
+++ b/spec/types/README.md
@@ -1,0 +1,5 @@
+General notes about the types of drivers. 
+
+Linking to more specific types details. 
+
+Leave this page mostly empty. It only exists for github browsing navigation. Link directly from spec root readme to these files. 

--- a/spec/types/base.md
+++ b/spec/types/base.md
@@ -1,0 +1,49 @@
+# Base Types Specification
+
+## Overview
+Base types define the core contract for all `mtng-unstorage` drivers. They ensure consistent configuration for common features like read-only mode, namespace isolation (prefixes), and safety guards (clearing storage).
+
+**Source**: `src/types/driver-base.ts`
+
+## Configuration Options (`MTBaseDriverOptions`)
+
+All drivers support these fundamental options:
+
+| Option | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `base` | `string` | `''` | Base path prefix for all keys. |
+| `storagePrefix` | `string` | `''` | Preferred storage prefix. Replaces legacy `s3StoragePrefix`. |
+| `name` | `string` | `undefined` | Driver name for debugging/logging. |
+| `readOnly` | `boolean` | `false` | If `true`, disables `setItem`, `removeItem`, and `clear`. |
+| `allowClear` | `boolean` | `false` | If `true`, enables the `clear` method. Defaults to `false` for safety. |
+| `maxDepth` | `number` | `undefined` | Maximum directory depth for operations. |
+
+### Derived Options (`ResolvedMTBaseDriverOptions`)
+Internal drivers use a resolved version of options where defaults are applied:
+- `fullBasePrefix`: Combines `base` + `storagePrefix`.
+
+## Driver Interface (`BaseDriverMethods`)
+
+The driver interface extends the standard `unstorage` driver but strictly types available methods based on configuration.
+
+### Methods
+- **`hasItem(key)`**: Check if an item exists.
+- **`getItem(key)`**: Retrieve an item.
+- **`getKeys(base?)`**: List available keys.
+- **`setItem(key, value)`**: Store an item (Unavailable in `readOnly`).
+- **`removeItem(key)`**: Delete an item (Unavailable in `readOnly`).
+- **`clear(base?)`**: Remove all items (Only available if `allowClear: true` AND `!readOnly`).
+
+## Conditional Typing (`ConditionalDriver`)
+
+TypeScript types are used to enforce configuration at compile time:
+
+```typescript
+// Example: Read-Only Driver
+const roDriver = awsS3Driver({ bucket: '...', readOnly: true });
+// roDriver.setItem(...) // Compile Error
+
+// Example: Safe Driver (Default)
+const safeDriver = awsS3Driver({ bucket: '...' });
+// safeDriver.clear() // Compile Error (allowClear defaults to false)
+```

--- a/spec/types/flex.md
+++ b/spec/types/flex.md
@@ -1,0 +1,50 @@
+# Flex Types Specification
+
+## Overview
+Flex types support advanced drivers (such as `awsS3FlexDriver`) that require custom key and value serialization logic.
+
+**Source**: `src/types/driver-flex.ts`
+
+## Key Mapping
+
+Flex drivers support `toStorageKey` and `fromStorageKey` mapping functions.
+
+- **`toStorageKey`**: Transform a standard key (e.g., `user:123`) to a storage-specific key (e.g., `users/123.json`).
+- **`fromStorageKey`**: Reverse map a storage key (e.g., `users/123.json`) back to a standard key (e.g., `user:123`).
+
+### Mapping Function Signature
+
+```typescript
+type KeyMapper = (params: {
+  key: string;
+  resolvedDriverOptions: ResolvedDriverOptions;
+  transactionOptions?: TransactionOptions;
+}) => string;
+```
+
+Key mapping functions receive the full driver configuration context, allowing dynamic prefixing or environment-specific rules.
+
+## Value Mapping
+
+Flex drivers support `toStorageValue` and `fromStorageValue` mapping functions for handling serialization.
+
+- **`toStorageValue`**: Convert a JavaScript object/value to a storage-compatible string (e.g., `JSON.stringify`).
+- **`fromStorageValue`**: Convert a storage string back to a JavaScript object/value (e.g., `JSON.parse`).
+
+### Mapping Function Signature
+
+```typescript
+type ValueMapper<TInput, TOutput> = (params: {
+  input: TInput;
+  resolvedDriverOptions: ResolvedDriverOptions;
+  transactionOptions?: TransactionOptions;
+}) => TOutput | Promise<TOutput>;
+```
+
+Value mappers can be async, allowing for complex transformations like compression or encryption.
+
+## Configuration Rules
+
+TypeScript ensures safe configuration:
+- If `toStorageKey` is provided, `fromStorageKey` is required (unless `readOnly: true`).
+- If `toStorageValue` is provided, `fromStorageValue` is required (unless `readOnly: true`).

--- a/spec/types/versioned.md
+++ b/spec/types/versioned.md
@@ -1,0 +1,15 @@
+# Versioned Types Specification
+
+## Overview
+> [!NOTE]
+> This feature is planned for a future release.
+
+Versioned types will support drivers that maintain history or versioning for stored items.
+
+**Source**: `src/types/driver-versioned.ts`
+
+## Proposed Features
+
+- **Store Version**: `setItem` may return a version ID or ETag.
+- **Get Version**: `getItem` may accept a version ID to retrieve a specific historical state.
+- **List Versions**: `getVersions(key)` to list available versions for a specific item.


### PR DESCRIPTION
## Description

This PR expands the driver specifications for `mtng-unstorage` and refines the documentation tone.

### Key Changes
- **New Specs**: Added specifications for `aws-ssm` and `aws-ddb` drivers.
- **Refinement**: Updated all specs to be more neutral and concise.
- **Testing**: Documented testing patterns and E2E configuration.
- **Type Links**: Connected driver specs to base, flex, and versioned type definitions.

### Related Issue
Closes #71

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus new test environment variable templates; no runtime code paths or APIs are modified.
> 
> **Overview**
> Adds a new `spec/` documentation set that formalizes driver/type specifications, including overviews for `aws-s3`, plus new spec pages for `aws-ssm` and `aws-ddb`, and accompanying type specs (`base`, `flex`, and planned `versioned`).
> 
> Documents the testing approach in `spec/testing.md` and extends the E2E env template (`.env.test.e2e`) with SSM toggles/prefix variables to support running SSM-focused E2E suites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aceefc0a54734050408e6eb5a3069f4378c77b1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->